### PR TITLE
Update to work with 1.4.4

### DIFF
--- a/[Source]/SigmaCartographer/MapExporter.cs
+++ b/[Source]/SigmaCartographer/MapExporter.cs
@@ -235,10 +235,21 @@ namespace SigmaRandomPlugin
             }
 
             // Get the mods
-            Action<PQS.VertexBuildData> modOnVertexBuildHeight = (Action<PQS.VertexBuildData>)Delegate.CreateDelegate(
-                typeof(Action<PQS.VertexBuildData>),
-                pqs,
-                typeof(PQS).GetMethod("Mod_OnVertexBuildHeight", BindingFlags.Instance | BindingFlags.NonPublic));
+            #if !KSP131
+            Action<PQS.VertexBuildData, Boolean> modOnVertexBuildHeight = 
+                (Action<PQS.VertexBuildData, Boolean>) Delegate.CreateDelegate(
+                    typeof(Action<PQS.VertexBuildData, Boolean>),
+                    pqs,
+                    typeof(PQS).GetMethod("Mod_OnVertexBuildHeight",
+                        BindingFlags.Instance | BindingFlags.NonPublic));
+            #else
+                Action<PQS.VertexBuildData> modOnVertexBuildHeight =
+                    (Action<PQS.VertexBuildData>) Delegate.CreateDelegate(
+                        typeof(Action<PQS.VertexBuildData>),
+                        pqs,
+                        typeof(PQS).GetMethod("Mod_OnVertexBuildHeight",
+                            BindingFlags.Instance | BindingFlags.NonPublic));
+                #endif
             Action<PQS.VertexBuildData> modOnVertexBuild = (Action<PQS.VertexBuildData>)Delegate.CreateDelegate(
                 typeof(Action<PQS.VertexBuildData>),
                 pqs,
@@ -273,7 +284,11 @@ namespace SigmaRandomPlugin
                                     };
 
                                     // Build from the Mods 
+                                    #if !KSP131
+                                    modOnVertexBuildHeight(data, true);
+                                    #else
                                     modOnVertexBuildHeight(data);
+                                    #endif
 
                                     if (exportHeightMap || exportNormalMap || exportSlopeMap || exportSatelliteMap)
                                     {


### PR DESCRIPTION
1.4.4 changed the signature of the Mod_OnVertexBuildHeight method so the
code using it needs to be adjusted. By setting the KSP131 flag in the
project settings you can compile cartographer in 1.3.1-compatible mode
(which in reality works on 1.3.1-1.4.3).