### PR TITLE
Choose to overwrite maps & possible settings in new Settings.cfg

### DIFF
--- a/[Source]/SigmaCartographer/MapGenerator.cs
+++ b/[Source]/SigmaCartographer/MapGenerator.cs
@@ -14,9 +14,8 @@ namespace SigmaCartographerPlugin
 
         internal static bool exportAny
         {
-            //--adding in a check to see whether maps exist. 2019-0830 STH
-            get { return exportHeightMap || exportNormalMap || exportSlopeMap || exportColorMap || exportOceanMap || satelliteAny || overwriteAny; }
-            set { exportHeightMap = exportNormalMap = exportSlopeMap = exportColorMap = exportOceanMap = satelliteAny = overwriteAny = value; }
+            get { return exportHeightMap || exportNormalMap || exportSlopeMap || exportColorMap || exportOceanMap || satelliteAny; }
+            set { exportHeightMap = exportNormalMap = exportSlopeMap = exportColorMap = exportOceanMap = satelliteAny = value; }
         }
 
         static bool satelliteAny
@@ -24,15 +23,6 @@ namespace SigmaCartographerPlugin
             get { return exportSatelliteHeight || exportSatelliteSlope || exportSatelliteMap || exportSatelliteBiome; }
             set { exportSatelliteHeight = exportSatelliteSlope = exportSatelliteMap = exportSatelliteBiome = value; }
         }
-
-        //------------------
-        //--adding in a check to see whether maps exist. 2019-0830 STH
-        static bool overwriteAny
-        {
-            get { return overwriteHeightMap || overwriteNormalMap || overwriteSlopeMap || overwriteColorMap || overwriteOceanMap || overwriteSatelliteHeight || overwriteSatelliteSlope || overwriteSatelliteMap || overwriteSatelliteBiome; }
-            set { overwriteHeightMap = overwriteNormalMap = overwriteSlopeMap = overwriteColorMap = overwriteOceanMap = overwriteSatelliteHeight = overwriteSatelliteSlope = overwriteSatelliteMap = overwriteSatelliteBiome = value; }
-        }
-        //------------------
 
         static bool exportHeightMap = false;
         static bool exportNormalMap = false;
@@ -45,21 +35,6 @@ namespace SigmaCartographerPlugin
         static bool exportSatelliteSlope = false;
         static bool exportSatelliteMap = false;
         static bool exportSatelliteBiome = false;
-
-        //------------------
-        //--adding in a check to see whether maps exist. 2019-0830 STH
-        static bool overwriteHeightMap = true;
-        static bool overwriteNormalMap = true;
-        static bool overwriteSlopeMap = true;
-        static bool overwriteColorMap = true;
-        static bool overwriteOceanMap = true;
-        internal static bool overwriteBiomeMap = true;
-
-        static bool overwriteSatelliteHeight = true;
-        static bool overwriteSatelliteSlope = true;
-        static bool overwriteSatelliteMap = true;
-        static bool overwriteSatelliteBiome = true;
-        //------------------
 
         internal static CelestialBody body;
         static int width = 2048;
@@ -97,20 +72,25 @@ namespace SigmaCartographerPlugin
         internal static void LoadSettings(ConfigNode node)
         {
             bool.TryParse(node.GetValue("heightMap"), out exportHeightMap);
+            bool.TryParse(node.GetValue("satelliteHeight"), out exportSatelliteHeight);
+
             bool.TryParse(node.GetValue("normalMap"), out exportNormalMap);
+
             bool.TryParse(node.GetValue("slopeMap"), out exportSlopeMap);
+            bool.TryParse(node.GetValue("satelliteSlope"), out exportSatelliteSlope);
+
             if (!bool.TryParse(node.GetValue("colorMap"), out exportColorMap))
             {
                 exportColorMap = true;
             }
-            bool.TryParse(node.GetValue("oceanMap"), out exportOceanMap);
-            bool.TryParse(node.GetValue("biomeMap"), out exportBiomeMap);
-
-            bool.TryParse(node.GetValue("satelliteHeight"), out exportSatelliteHeight);
-            bool.TryParse(node.GetValue("satelliteSlope"), out exportSatelliteSlope);
             bool.TryParse(node.GetValue("satelliteMap"), out exportSatelliteMap);
+
+            bool.TryParse(node.GetValue("oceanMap"), out exportOceanMap);
+
+            bool.TryParse(node.GetValue("biomeMap"), out exportBiomeMap);
             bool.TryParse(node.GetValue("satelliteBiome"), out exportSatelliteBiome);
-            
+
+
             if (!exportAny && !exportBiomeMap) return;
 
             string bodyName = node.GetValue("body");

--- a/[Source]/SigmaCartographer/MapGenerator.cs
+++ b/[Source]/SigmaCartographer/MapGenerator.cs
@@ -14,8 +14,9 @@ namespace SigmaCartographerPlugin
 
         internal static bool exportAny
         {
-            get { return exportHeightMap || exportNormalMap || exportSlopeMap || exportColorMap || exportOceanMap || satelliteAny; }
-            set { exportHeightMap = exportNormalMap = exportSlopeMap = exportColorMap = exportOceanMap = satelliteAny = value; }
+            //--adding in a check to see whether maps exist. 2019-0830 STH
+            get { return exportHeightMap || exportNormalMap || exportSlopeMap || exportColorMap || exportOceanMap || satelliteAny || overwriteAny; }
+            set { exportHeightMap = exportNormalMap = exportSlopeMap = exportColorMap = exportOceanMap = satelliteAny = overwriteAny = value; }
         }
 
         static bool satelliteAny
@@ -23,6 +24,15 @@ namespace SigmaCartographerPlugin
             get { return exportSatelliteHeight || exportSatelliteSlope || exportSatelliteMap || exportSatelliteBiome; }
             set { exportSatelliteHeight = exportSatelliteSlope = exportSatelliteMap = exportSatelliteBiome = value; }
         }
+
+        //------------------
+        //--adding in a check to see whether maps exist. 2019-0830 STH
+        static bool overwriteAny
+        {
+            get { return overwriteHeightMap || overwriteNormalMap || overwriteSlopeMap || overwriteColorMap || overwriteOceanMap || overwriteSatelliteHeight || overwriteSatelliteSlope || overwriteSatelliteMap || overwriteSatelliteBiome; }
+            set { overwriteHeightMap = overwriteNormalMap = overwriteSlopeMap = overwriteColorMap = overwriteOceanMap = overwriteSatelliteHeight = overwriteSatelliteSlope = overwriteSatelliteMap = overwriteSatelliteBiome = value; }
+        }
+        //------------------
 
         static bool exportHeightMap = false;
         static bool exportNormalMap = false;
@@ -35,6 +45,21 @@ namespace SigmaCartographerPlugin
         static bool exportSatelliteSlope = false;
         static bool exportSatelliteMap = false;
         static bool exportSatelliteBiome = false;
+
+        //------------------
+        //--adding in a check to see whether maps exist. 2019-0830 STH
+        static bool overwriteHeightMap = true;
+        static bool overwriteNormalMap = false;
+        static bool overwriteSlopeMap = false;
+        static bool overwriteColorMap = true;
+        static bool overwriteOceanMap = false;
+        internal static bool overwriteBiomeMap = false;
+
+        static bool overwriteSatelliteHeight = false;
+        static bool overwriteSatelliteSlope = false;
+        static bool overwriteSatelliteMap = false;
+        static bool overwriteSatelliteBiome = false;
+        //------------------
 
         internal static CelestialBody body;
         static int width = 2048;
@@ -72,25 +97,20 @@ namespace SigmaCartographerPlugin
         internal static void LoadSettings(ConfigNode node)
         {
             bool.TryParse(node.GetValue("heightMap"), out exportHeightMap);
-            bool.TryParse(node.GetValue("satelliteHeight"), out exportSatelliteHeight);
-
             bool.TryParse(node.GetValue("normalMap"), out exportNormalMap);
-
             bool.TryParse(node.GetValue("slopeMap"), out exportSlopeMap);
-            bool.TryParse(node.GetValue("satelliteSlope"), out exportSatelliteSlope);
-
             if (!bool.TryParse(node.GetValue("colorMap"), out exportColorMap))
             {
                 exportColorMap = true;
             }
-            bool.TryParse(node.GetValue("satelliteMap"), out exportSatelliteMap);
-
             bool.TryParse(node.GetValue("oceanMap"), out exportOceanMap);
-
             bool.TryParse(node.GetValue("biomeMap"), out exportBiomeMap);
+
+            bool.TryParse(node.GetValue("satelliteHeight"), out exportSatelliteHeight);
+            bool.TryParse(node.GetValue("satelliteSlope"), out exportSatelliteSlope);
+            bool.TryParse(node.GetValue("satelliteMap"), out exportSatelliteMap);
             bool.TryParse(node.GetValue("satelliteBiome"), out exportSatelliteBiome);
-
-
+            
             if (!exportAny && !exportBiomeMap) return;
 
             string bodyName = node.GetValue("body");

--- a/[Source]/SigmaCartographer/MapGenerator.cs
+++ b/[Source]/SigmaCartographer/MapGenerator.cs
@@ -36,6 +36,21 @@ namespace SigmaCartographerPlugin
         static bool exportSatelliteMap = false;
         static bool exportSatelliteBiome = false;
 
+        //------------------
+        //--adding in a check to see whether maps exist. 2019-0830 STH
+        static bool overwriteHeightMap = true;
+        static bool overwriteNormalMap = true;
+        static bool overwriteSlopeMap = true;
+        static bool overwriteColorMap = true;
+        static bool overwriteOceanMap = true;
+        internal static bool overwriteBiomeMap = true;
+
+        static bool overwriteSatelliteHeight = true;
+        static bool overwriteSatelliteSlope = true;
+        static bool overwriteSatelliteMap = true;
+        static bool overwriteSatelliteBiome = true;
+        //------------------
+
         internal static CelestialBody body;
         static int width = 2048;
         static int tile = 1024;
@@ -90,6 +105,20 @@ namespace SigmaCartographerPlugin
             bool.TryParse(node.GetValue("biomeMap"), out exportBiomeMap);
             bool.TryParse(node.GetValue("satelliteBiome"), out exportSatelliteBiome);
 
+            //------------------
+            //--adding in a check to see whether maps exist. 2019-0830 STH
+            bool.TryParse(node.GetValue("overwriteHeightMap"), out overwriteHeightMap);
+            bool.TryParse(node.GetValue("overwriteNormalMap"), out overwriteNormalMap);
+            bool.TryParse(node.GetValue("overwriteSlopeMap"), out overwriteSlopeMap);
+            bool.TryParse(node.GetValue("overwriteColorMap"), out overwriteColorMap);
+            bool.TryParse(node.GetValue("overwriteOceanMap"), out overwriteOceanMap);
+            bool.TryParse(node.GetValue("overwriteBiomeMap"), out overwriteBiomeMap);
+
+            bool.TryParse(node.GetValue("overwriteSatelliteHeight"), out overwriteSatelliteHeight);
+            bool.TryParse(node.GetValue("overwriteSatelliteSlope"), out overwriteSatelliteSlope);
+            bool.TryParse(node.GetValue("overwriteSatelliteMap"), out overwriteSatelliteMap);
+            bool.TryParse(node.GetValue("overwriteSatelliteBiome"), out overwriteSatelliteBiome);
+            //------------------
 
             if (!exportAny && !exportBiomeMap) return;
 
@@ -280,6 +309,89 @@ namespace SigmaCartographerPlugin
 
             // reset current
             current = 0;
+            //generate folder & file names
+            int position = Flip(current);
+            //string folder = leaflet ? (position % (width / tile) + "/") : "";
+            //string fileName = leaflet ? (position / (width / tile)) + ".png" : "Tile" + position.ToString("D4") + ".png";
+            // Expanded statements for greater understandability. STH 2019-0831
+            string folder;
+            string fileName;
+            if (leaflet){
+                folder = (position % (width / tile) + "/");
+                fileName = (position / (width / tile)) + ".png";
+            }
+            else
+            {
+                folder = "";
+                fileName = "Tile" + position.ToString("D4") + ".png";
+            }
+
+            //--------------------------
+            //put checks for images here
+            //STH 2019-0831
+            string checkFile;
+            checkFile = exportFolder + folder + "HeightMap/" + fileName;
+            if (File.Exists(checkFile) && !overwriteHeightMap)
+            {
+                exportHeightMap = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of HeightMap skipped");
+            }
+            checkFile = exportFolder + folder + "NormalMap/" + fileName;
+            if (File.Exists(checkFile) && !overwriteNormalMap)
+            {
+                exportNormalMap = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of NormalMap skipped");
+            }
+            checkFile = exportFolder + folder + "SlopeMap/" + fileName;
+            if (File.Exists(checkFile) && !overwriteSlopeMap)
+            {
+                exportSlopeMap = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of SlopeMap skipped");
+            }
+            checkFile = exportFolder + folder + "ColorMap/" + fileName;
+            if (File.Exists(checkFile) && !overwriteColorMap)
+            {
+                exportColorMap = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of ColorMap skipped");
+            }
+            checkFile = exportFolder + folder + "OceanMap/" + fileName;
+            if (File.Exists(checkFile) && !overwriteOceanMap)
+            {
+                exportOceanMap = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of OceanMap skipped");
+            }
+            checkFile = exportFolder + folder + "BiomeMap/" + fileName;
+            if (File.Exists(checkFile) && !overwriteBiomeMap)
+            {
+                exportBiomeMap = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of BiomeMap skipped");
+            }
+            //sat maps
+            checkFile = exportFolder + folder + "SatelliteHeight/" + fileName;
+            if (File.Exists(checkFile) && !overwriteSatelliteHeight)
+            {
+                exportSatelliteHeight = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of SatelliteHeight skipped");
+            }
+            checkFile = exportFolder + folder + "SatelliteSlope/" + fileName;
+            if (File.Exists(checkFile) && !overwriteSatelliteSlope)
+            {
+                exportSatelliteSlope = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of SatelliteSlope skipped");
+            }
+            checkFile = exportFolder + folder + "SatelliteMap/" + fileName;
+            if (File.Exists(checkFile) && !overwriteSatelliteMap)
+            {
+                exportSatelliteMap = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of SatelliteMap skipped");
+            }
+            checkFile = exportFolder + folder + "SatelliteBiome/" + fileName;
+            if (File.Exists(checkFile) && !overwriteSatelliteBiome)
+            {
+                exportSatelliteBiome = false;
+                //UnityEngine.Debug.Log(Debug.Tag + " Overwrite of SatelliteBiome skipped");
+            }
+            //--------------------------
 
             // Get PQS
             PQS pqs = null;
@@ -488,9 +600,13 @@ namespace SigmaCartographerPlugin
                         }
 
                         // Serialize them to disk
-                        int position = Flip(current);
-                        string folder = leaflet ? (position % (width / tile) + "/") : "";
-                        string fileName = leaflet ? (position / (width / tile)) + ".png" : "Tile" + position.ToString("D4") + ".png";
+                        //--------
+                        //moved to before processing
+                        //STH 2019-0831
+                        //int position = Flip(current);
+                        //string folder = leaflet ? (position % (width / tile) + "/") : "";
+                        //string fileName = leaflet ? (position / (width / tile)) + ".png" : "Tile" + position.ToString("D4") + ".png";
+                        //--------
 
                         // Export
                         try

--- a/[Source]/SigmaCartographer/MapGenerator.cs
+++ b/[Source]/SigmaCartographer/MapGenerator.cs
@@ -49,16 +49,16 @@ namespace SigmaCartographerPlugin
         //------------------
         //--adding in a check to see whether maps exist. 2019-0830 STH
         static bool overwriteHeightMap = true;
-        static bool overwriteNormalMap = false;
-        static bool overwriteSlopeMap = false;
+        static bool overwriteNormalMap = true;
+        static bool overwriteSlopeMap = true;
         static bool overwriteColorMap = true;
-        static bool overwriteOceanMap = false;
-        internal static bool overwriteBiomeMap = false;
+        static bool overwriteOceanMap = true;
+        internal static bool overwriteBiomeMap = true;
 
-        static bool overwriteSatelliteHeight = false;
-        static bool overwriteSatelliteSlope = false;
-        static bool overwriteSatelliteMap = false;
-        static bool overwriteSatelliteBiome = false;
+        static bool overwriteSatelliteHeight = true;
+        static bool overwriteSatelliteSlope = true;
+        static bool overwriteSatelliteMap = true;
+        static bool overwriteSatelliteBiome = true;
         //------------------
 
         internal static CelestialBody body;

--- a/[Source]/SigmaCartographer/UserSettings.cs
+++ b/[Source]/SigmaCartographer/UserSettings.cs
@@ -39,7 +39,83 @@ namespace SigmaCartographerPlugin
             {
                 UnityEngine.Debug.Log(Debug.Tag + " WARNING: Missing file => " + folder + file + ".cfg");
                 UnityEngine.Debug.Log(Debug.Tag + "          Writing file => " + folder + file + ".cfg");
-                File.WriteAllLines(folder + file + ".cfg", new[] { nodeName + " {}" });
+                //File.WriteAllLines(folder + file + ".cfg", new[] { nodeName + " {}" });
+                //------
+                //The following writes the default Settings.cfg file
+                //but includes commented lines that can act as documentation
+                //for users.
+                //STH 2019-0831
+                File.WriteAllLines(
+                    folder + file + ".cfg",
+                    new string[]
+                    {
+                        "//The configuration file has the following format:",
+                        "//"+nodeName,
+                        "//{",
+                        "// Maps",
+                        "// {",
+                        "//     body = Kerbin   // the name of the body           (default = Kerbin)",
+                        "//     width = 2048    // the total width of the texture (default = 2048)",
+                        "//     tile = 1024     // the width of one﻿ tile          (default = 1024)",
+                        "//     flipV = false   // flip the image vertically      (default = false)",
+                        "//     flipH = false   // flip the image horizontally    (default = false)",
+                        "//     exportFolder = Sigma/Cartographer/Maps        // path for the export folder",
+                        "//     leaflet = false // export in folders divided by columns and rows (default = false)",
+                        "//",
+                        "//     heightMap = false       // export height map        (default = false)",
+                        "//     normalMap = false       // ?                        (default = false)",
+                        "//     slopeMap = false        // export slope map         (default = false)",
+                        "//     colorMap = true         // ?                        (default = true)",
+                        "//     oceanMap = false        // export surface ocean     (default = false)",                     
+                        "//     biomeMap = false        // export biome map         (default = false)",
+                        "//     satelliteHeight = false // if true, forces heightMap to be true (default = false)",
+                        "//     satelliteSlope = false  // if true, forces slopeMap to be true  (default = false)",
+                        "//     satelliteMap = false    // if true, forces colorMap to be true  (default = false)",
+                        "//     satelliteBiome = false  // if true, forces biomeMap to be true  (default = false)",
+                        "//",
+                        "//     //To have Sigma Cartographer export images only if they don't exist:",
+                        "//     overwriteHeightMap = false      //(default = true)",
+                        "//     overwriteNormalMap = false      //(default = true)",
+                        "//     overwriteSlopeMap = false       //(default = true)",
+                        "//     overwriteColorMap = false       //(default = true)",
+                        "//     overwriteOceanMap = false       //(default = true)",
+                        "//     overwriteBiomeMap = false       //(default = true)",
+                        "//",
+                        "//     overwriteSatelliteHeight = true //(default = true)",
+                        "//     overwriteSatelliteSlope = true  //(default = true)",
+                        "//     overwriteSatelliteMap = true    //(default = true)",
+                        "//     overwriteSatelliteBiome = true  //(default = true)",
+                        "//-----------",
+                        "//     oceanFloor = true      // include the ocean floor on maps. (default = true)",
+                        "//",
+                        "//     normalStrength = 1     // strength of normals (default = 1)",
+                        "//     slopeMin = 0.2,0.3,0.4 // color for  0° slope (default = 0.2,0.3,0.4)",
+                        "//     slopeMax = 0.9,0.6,0.5 // color for 90° slope (default = 0.9,0.6,0.5)",
+                        "//",
+                        "//     LAToffset = 0          // offset latitude  (default = 0)",
+                        "//     LONoffset = 0          // offset longitude (default = 0)",
+                        "//",
+                        "//     //if you want to print only selected tiles",
+                        "//     //add as many of these as you want",
+                        "//     //if you don't add any of these",
+                        "//     //all tiles will be exported",
+                        "//     printTile = 0",
+                        "//     printTile = 1",
+                        "// }",
+                        "// Info",
+                        "// {",
+                        "//     //List all the bodies for which you want info on",
+                        "//     //the lowest and highest point on the planet.",
+                        "//     //Examples:",    
+                        "//     body = Kerbin",
+                        "//     body = Mun",
+                        "// }",
+                        "//}",
+                        "",
+                        nodeName + " {}"
+                    }
+                );
+                //-------
                 return;
             }
 

--- a/[Source]/SigmaCartographer/UserSettings.cs
+++ b/[Source]/SigmaCartographer/UserSettings.cs
@@ -38,7 +38,7 @@ namespace SigmaCartographerPlugin
             if (!File.Exists(folder + file + ".cfg"))
             {
                 UnityEngine.Debug.Log(Debug.Tag + " WARNING: Missing file => " + folder + file + ".cfg");
-
+                UnityEngine.Debug.Log(Debug.Tag + "          Writing file => " + folder + file + ".cfg");
                 File.WriteAllLines(folder + file + ".cfg", new[] { nodeName + " {}" });
                 return;
             }


### PR DESCRIPTION
Included ability for user to specify whether existing maps should be overwritter on a per map type basis. This allows the user to leave Cartographer in the mods folder without impacting load time in a significant way if they specify that existing maps should not be overwritten on each game load. This address #22 

I also included info written to the first-run generation of the Settings.cfg that provides potential settings. This partly addresses #17 , and can be expanded upon with relative ease.